### PR TITLE
Singleton neo4j

### DIFF
--- a/__mocks__/leaflet.js
+++ b/__mocks__/leaflet.js
@@ -9,162 +9,162 @@ import { L } from 'leaflet';
 const LeafletMock = jest.createMockFromModule('leaflet')
 
 class ControlMock extends LeafletMock.Control {
-    constructor(options) {
-      super()
-      this.options = { ...L.Control.prototype.options, ...options }
+  constructor(options) {
+    super()
+    this.options = { ...L.Control.prototype.options, ...options }
+  }
+
+  getPosition() {
+    return this.options.position
+  }
+
+  setPosition(position) {
+    this.options.position = position
+    return this
+  }
+}
+
+const controlMock = (options) => new ControlMock(options)
+
+class LayersControlMock extends ControlMock {
+  constructor(baseLayers = [], overlays = [], options) {
+    super(options)
+    this._layers = []
+
+    baseLayers.forEach((layer, i) => {
+      this._addLayer(layer, i)
+    })
+    overlays.forEach((layer, i) => {
+      this._addLayer(layer, i, true)
+    })
+  }
+
+  _addLayer(layer, name, overlay) {
+    this._layers.push({ layer, name, overlay })
+  }
+
+  addBaseLayer(layer, name) {
+    this._addLayer(layer, name)
+    return this
+  }
+
+  addOverlay(layer, name) {
+    this._addLayer(layer, name, true)
+    return this
+  }
+
+  removeLayer(obj) {
+    this._layers.splice(this._layers.indexOf(obj), 1)
+  }
+}
+
+ControlMock.Layers = LayersControlMock
+controlMock.layers = (baseLayers, overlays, options) => {
+  return new LayersControlMock(baseLayers, overlays, options)
+}
+
+class MapMock extends LeafletMock.Map {
+  constructor(id, options = {}) {
+    super()
+    Object.assign(this, L.Evented.prototype)
+
+    this.options = { ...L.Map.prototype.options, ...options }
+    this._container = id
+
+    if (options.bounds) {
+      this.fitBounds(options.bounds, options.boundsOptions)
     }
 
-    getPosition() {
-      return this.options.position
+    if (options.maxBounds) {
+      this.setMaxBounds(options.maxBounds)
     }
 
-    setPosition(position) {
-      this.options.position = position
-      return this
+    if (options.center && options.zoom !== undefined) {
+      this.setView(L.latLng(options.center), options.zoom)
     }
   }
 
-  const controlMock = (options) => new ControlMock(options)
-
-  class LayersControlMock extends ControlMock {
-    constructor(baseLayers = [], overlays = [], options) {
-      super(options)
-      this._layers = []
-
-      baseLayers.forEach((layer, i) => {
-        this._addLayer(layer, i)
-      })
-      overlays.forEach((layer, i) => {
-        this._addLayer(layer, i, true)
-      })
-    }
-
-    _addLayer(layer, name, overlay) {
-      this._layers.push({ layer, name, overlay })
-    }
-
-    addBaseLayer(layer, name) {
-      this._addLayer(layer, name)
-      return this
-    }
-
-    addOverlay(layer, name) {
-      this._addLayer(layer, name, true)
-      return this
-    }
-
-    removeLayer(obj) {
-      this._layers.splice(this._layers.indexOf(obj), 1)
-    }
+  _limitZoom(zoom) {
+    const min = this.getMinZoom()
+    const max = this.getMaxZoom()
+    return Math.max(min, Math.min(max, zoom))
   }
 
-  ControlMock.Layers = LayersControlMock
-  controlMock.layers = (baseLayers, overlays, options) => {
-    return new LayersControlMock(baseLayers, overlays, options)
+  _resetView(center, zoom) {
+    this._initialCenter = center
+    this._zoom = zoom
   }
 
-  class MapMock extends LeafletMock.Map {
-    constructor(id, options = {}) {
-      super()
-      Object.assign(this, L.Evented.prototype)
-
-      this.options = { ...L.Map.prototype.options, ...options }
-      this._container = id
-
-      if (options.bounds) {
-        this.fitBounds(options.bounds, options.boundsOptions)
-      }
-
-      if (options.maxBounds) {
-        this.setMaxBounds(options.maxBounds)
-      }
-
-      if (options.center && options.zoom !== undefined) {
-        this.setView(L.latLng(options.center), options.zoom)
-      }
-    }
-
-    _limitZoom(zoom) {
-      const min = this.getMinZoom()
-      const max = this.getMaxZoom()
-      return Math.max(min, Math.min(max, zoom))
-    }
-
-    _resetView(center, zoom) {
-      this._initialCenter = center
-      this._zoom = zoom
-    }
-
-    fitBounds(bounds, options) {
-      this._bounds = bounds
-      this._boundsOptions = options
-    }
-
-    getBounds() {
-      return this._bounds
-    }
-
-    getCenter() {
-      return this._initialCenter
-    }
-
-    getMaxZoom() {
-      return this.options.maxZoom === undefined ? Infinity : this.options.maxZoom
-    }
-
-    getMinZoom() {
-      return this.options.minZoom === undefined ? 0 : this.options.minZoom
-    }
-
-    getZoom() {
-      return this._zoom
-    }
-
-    setMaxBounds(bounds) {
-      bounds = L.latLngBounds(bounds)
-      this.options.maxBounds = bounds
-      return this
-    }
-
-    setView(center, zoom) {
-      zoom = zoom === undefined ? this.getZoom() : zoom
-      this._resetView(L.latLng(center), this._limitZoom(zoom))
-      return this
-    }
-
-    setZoom(zoom) {
-      return this.setView(this.getCenter(), zoom)
-    }
+  fitBounds(bounds, options) {
+    this._bounds = bounds
+    this._boundsOptions = options
   }
 
-  class PopupMock extends LeafletMock.Popup {
-    constructor(options, source) {
-      super()
-      Object.assign(this, L.Evented.prototype)
-
-      this.options = { ...L.Popup.prototype.options, ...options }
-      this._source = source
-    }
-
-    getContent() {
-      return this._content
-    }
-
-    setContent(content) {
-      this._content = content
-    }
+  getBounds() {
+    return this._bounds
   }
 
-  module.exports = {
-    ...LeafletMock,
-    Control: ControlMock,
-    control: controlMock,
-    LatLng: L.LatLng,
-    latLng: L.latLng,
-    LatLngBounds: L.LatLngBounds,
-    latLngBounds: L.latLngBounds,
-    Map: MapMock,
-    map: (id, options) => new MapMock(id, options),
-    Popup: PopupMock,
-    popup: (options, source) => new PopupMock(options, source),
+  getCenter() {
+    return this._initialCenter
   }
+
+  getMaxZoom() {
+    return this.options.maxZoom === undefined ? Infinity : this.options.maxZoom
+  }
+
+  getMinZoom() {
+    return this.options.minZoom === undefined ? 0 : this.options.minZoom
+  }
+
+  getZoom() {
+    return this._zoom
+  }
+
+  setMaxBounds(bounds) {
+    bounds = L.latLngBounds(bounds)
+    this.options.maxBounds = bounds
+    return this
+  }
+
+  setView(center, zoom) {
+    zoom = zoom === undefined ? this.getZoom() : zoom
+    this._resetView(L.latLng(center), this._limitZoom(zoom))
+    return this
+  }
+
+  setZoom(zoom) {
+    return this.setView(this.getCenter(), zoom)
+  }
+}
+
+class PopupMock extends LeafletMock.Popup {
+  constructor(options, source) {
+    super()
+    Object.assign(this, L.Evented.prototype)
+
+    this.options = { ...L.Popup.prototype.options, ...options }
+    this._source = source
+  }
+
+  getContent() {
+    return this._content
+  }
+
+  setContent(content) {
+    this._content = content
+  }
+}
+
+module.exports = {
+  ...LeafletMock,
+  Control: ControlMock,
+  control: controlMock,
+  LatLng: L.LatLng,
+  latLng: L.latLng,
+  LatLngBounds: L.LatLngBounds,
+  latLngBounds: L.latLngBounds,
+  Map: MapMock,
+  map: (id, options) => new MapMock(id, options),
+  Popup: PopupMock,
+  popup: (options, source) => new PopupMock(options, source),
+}

--- a/__mocks__/neo4jDesktopApi.js
+++ b/__mocks__/neo4jDesktopApi.js
@@ -1,0 +1,33 @@
+Object.defineProperty(window, 'neo4jDesktopApi', {
+  writable: true,
+  value: {
+    getContext: jest.fn().mockImplementation(() => {
+      const mockGraph = {
+        name: 'mock graph',
+        description: 'mock graph for testing',
+        status: 'ACTIVE',
+        connection: {
+          configuration: {
+            protocols: {
+              bolt: {
+                url: '',
+                username: '',
+                password: ''
+              }
+            }
+          }
+        }
+      }
+
+      const mockProject = {
+        graphs: [mockGraph]
+      }
+
+      const mockContext = {
+        projects: [mockProject]
+      }
+
+      return Promise.resolve(mockContext);
+    })
+  }
+});

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React from "react";
-import neo4jService from './services/neo4jService'
 import download from "downloadjs";
 import { Map } from "./components/Map";
 import { Menu } from "./components/Menu";
@@ -10,21 +9,6 @@ import "./App.css";
 export const App = React.memo(() => {
 
 	const [layers, setLayers] = React.useState([]);
-	const [ready, setReady] = React.useState(false);
-	const driverRef = React.useRef(undefined);
-
-	// This blocks render indefinitely if the driver is never resolved.
-	// A better pattern would be to render anyway without driver,
-	// only calling getDriver() when a module wants to use the driver.
-	// Error handle incase driver is not resolved at that point.
-
-	// TODO: Remove boot blocker
-	React.useEffect(() => {
-		neo4jService.getNeo4jDriver().then(result => {
-			driverRef.current = result;
-			setReady(true);
-		});
-	});
 
 	const addLayer = (layer) => {
 		setLayers([...layers, layer]);
@@ -76,26 +60,23 @@ export const App = React.memo(() => {
 		e.preventDefault();
 	};
 
-	return <React.Suspense fallback={<span>Loading...</span>}>
-		{ready && (
-			<div id="wrapper" className="row">
-				<div id="sidebar" className="col-md-4">
-					<Menu saveConfigToFile={saveConfigToFile} loadConfigFromFile={loadConfigFromFile} />
-					<SideBar
-						driver = {driverRef.current}
-						layers={layers}
-						addLayer={addLayer}
-						updateLayer={updateLayer}
-						removeLayer={removeLayer}
-					/>
-				</div>
-				<div id="app-maparea" className="col-md-8">
-					<Map
-						key="map"
-						layers={layers}
-					/>
-				</div>
+	return (
+		<div id="wrapper" className="row">
+			<div id="sidebar" className="col-md-4">
+				<Menu saveConfigToFile={saveConfigToFile} loadConfigFromFile={loadConfigFromFile} />
+				<SideBar
+					layers={layers}
+					addLayer={addLayer}
+					updateLayer={updateLayer}
+					removeLayer={removeLayer}
+				/>
 			</div>
-		)}
-	</React.Suspense>
+			<div id="app-maparea" className="col-md-8">
+				<Map
+					key="map"
+					layers={layers}
+				/>
+			</div>
+		</div>
+	);
 });

--- a/src/components/Layer.js
+++ b/src/components/Layer.js
@@ -9,8 +9,8 @@ import Card from 'react-bootstrap/Card';
 import {Button, Form} from 'react-bootstrap';
 import {CypherEditor} from "graph-app-kit/components/Editor"
 import {confirmAlert} from 'react-confirm-alert'; // Import
-import neo4jService from '../services/neo4jService'
-import {ColorPicker} from "./ColorPicker";
+import { neo4jService } from '../services/neo4jService'
+import { ColorPicker } from "./ColorPicker";
 
 
 import 'react-confirm-alert/src/react-confirm-alert.css'; // Import css
@@ -38,8 +38,6 @@ export class Layer extends Component {
 		super(props);
 
 		this.state = props.layer;
-
-		this.driver = props.driver;
 
 		this.showQuery = this.showQuery.bind(this);
 		this.handleNameChange = this.handleNameChange.bind(this);
@@ -186,7 +184,7 @@ export class Layer extends Component {
 	async updateData() {
 		/*Query database and update `this.state.data`
          */
-		const [status, result] = await neo4jService.getData(this.driver, this.getQuery(), {});
+		const [status, result] = await neo4jService.getData( this.getQuery(), {});
 
 		if (status === "ERROR") {
 			let message = "Invalid cypher query.";
@@ -339,7 +337,7 @@ export class Layer extends Component {
 
 
 	async hasSpatialPlugin() {
-		const result = await neo4jService.hasSpatial(this.driver);
+		const result = await neo4jService.hasSpatial();
 
 		this.setState({
 			hasSpatialPlugin: result
@@ -351,7 +349,7 @@ export class Layer extends Component {
 		/*This will be updated quite often,
            is that what we want?
          */
-		const result = await neo4jService.getNodeLabels(this.driver);
+		const result = await neo4jService.getNodeLabels();
 
 		this.setState({
 			nodes: result
@@ -360,7 +358,7 @@ export class Layer extends Component {
 
 
 	async getPropertyNames() {
-		const result = await neo4jService.getProperties(this.driver, this.getNodeFilter());
+		const result = await neo4jService.getProperties( this.getNodeFilter());
 
 		// TODO: find a better way of appending no tooltip
 		result.push({value: "", label: ""}); // This is the default: no tooltip
@@ -370,7 +368,7 @@ export class Layer extends Component {
 
 
 	async getSpatialLayers() {
-		const result = neo4jService.getSpatialLayers(this.driver);
+		const result = neo4jService.getSpatialLayers();
 
 		this.setState({spatialLayers: result});
 	};

--- a/src/components/Layer.js
+++ b/src/components/Layer.js
@@ -184,7 +184,7 @@ export class Layer extends Component {
 	async updateData() {
 		const { status, error, result } = await neo4jService.getData( this.getQuery(), {});
 
-		if (status === 200 && result) {
+		if (status === 200 && result !== undefined) {
 			this.setState({ data: result }, function () {
 				this.updateBounds()
 			});
@@ -342,7 +342,7 @@ export class Layer extends Component {
 	async hasSpatialPlugin() {
 		const { status, error, result } = await neo4jService.hasSpatial();
 
-		if (status === 200 && result) {
+		if (status === 200 && result !== undefined) {
 			this.setState({	hasSpatialPlugin: result });
 		} else {
 			// TODO: Add Error UX. This should probably block creating/updating layer
@@ -358,7 +358,7 @@ export class Layer extends Component {
          */
 		const { status, error, result } = await neo4jService.getNodeLabels();
 		
-		if (status === 200 && result) {
+		if (status === 200 && result !== undefined) {
 			this.setState({	nodes: result });
 		} else {
 			// TODO: Add Error UX. This should probably block creating/updating layer
@@ -370,7 +370,7 @@ export class Layer extends Component {
 	async getPropertyNames() {
 		const { status, error, result } = await neo4jService.getProperties( this.getNodeFilter());
 
-		if (status === 200 && result) {
+		if (status === 200 && result !== undefined) {
 			const defaultNoTooltip = {value: "", label: ""};
 			this.setState({ propertyNames: [...result, defaultNoTooltip] });
 		} else {
@@ -381,9 +381,9 @@ export class Layer extends Component {
 
 
 	async getSpatialLayers() {
-		const { status, error, result } = neo4jService.getSpatialLayers();
+		const { status, error, result } = await neo4jService.getSpatialLayers();
 
-		if (status === 200 && result) {
+		if (status === 200 && result !== undefined) {
 			this.setState({ spatialLayers: result });
 		} else {
 			// TODO: Add Error UX. This should probably block creating/updating layer

--- a/src/components/Layer.js
+++ b/src/components/Layer.js
@@ -182,11 +182,16 @@ export class Layer extends Component {
 
 
 	async updateData() {
-		/*Query database and update `this.state.data`
-         */
-		const [status, result] = await neo4jService.getData( this.getQuery(), {});
+		const { status, error, result } = await neo4jService.getData( this.getQuery(), {});
 
-		if (status === "ERROR") {
+		if (status === 200 && result) {
+			this.setState({ data: result }, function () {
+				this.updateBounds()
+			});
+		} else if (result) {
+			// TODO: Add Error UX. This should probably block creating/updating layer
+			console.log(error);
+
 			let message = "Invalid cypher query.";
 			if (this.state.layerType !== LAYER_TYPE_CYPHER) {
 				message += "\nContact the development team";
@@ -194,11 +199,9 @@ export class Layer extends Component {
 				message += "\nFix your query and try again";
 			}
 			message += "\n\n" + result;
+
+			// Deprecate alert in favor of a less jarring error UX
 			alert(message);
-		} else if (result) {
-			this.setState({data: result}, function () {
-				this.updateBounds()
-			});
 		}
 	};
 
@@ -337,11 +340,15 @@ export class Layer extends Component {
 
 
 	async hasSpatialPlugin() {
-		const result = await neo4jService.hasSpatial();
+		const { status, error, result } = await neo4jService.hasSpatial();
 
-		this.setState({
-			hasSpatialPlugin: result
-		});
+		if (status === 200 && result) {
+			this.setState({	hasSpatialPlugin: result });
+		} else {
+			// TODO: Add Error UX. This should probably block creating/updating layer
+			console.log(error);
+		}
+
 	};
 
 
@@ -349,28 +356,39 @@ export class Layer extends Component {
 		/*This will be updated quite often,
            is that what we want?
          */
-		const result = await neo4jService.getNodeLabels();
-
-		this.setState({
-			nodes: result
-		})
+		const { status, error, result } = await neo4jService.getNodeLabels();
+		
+		if (status === 200 && result) {
+			this.setState({	nodes: result });
+		} else {
+			// TODO: Add Error UX. This should probably block creating/updating layer
+			console.log(error);
+		}
 	};
 
 
 	async getPropertyNames() {
-		const result = await neo4jService.getProperties( this.getNodeFilter());
+		const { status, error, result } = await neo4jService.getProperties( this.getNodeFilter());
 
-		// TODO: find a better way of appending no tooltip
-		result.push({value: "", label: ""}); // This is the default: no tooltip
-
-		this.setState({propertyNames: result});
+		if (status === 200 && result) {
+			const defaultNoTooltip = {value: "", label: ""};
+			this.setState({ propertyNames: [...result, defaultNoTooltip] });
+		} else {
+			// TODO: Add Error UX. This should probably block creating/updating layer
+			console.log(error);
+		}
 	};
 
 
 	async getSpatialLayers() {
-		const result = neo4jService.getSpatialLayers();
+		const { status, error, result } = neo4jService.getSpatialLayers();
 
-		this.setState({spatialLayers: result});
+		if (status === 200 && result) {
+			this.setState({ spatialLayers: result });
+		} else {
+			// TODO: Add Error UX. This should probably block creating/updating layer
+			console.log(error);
+		}
 	};
 
 

--- a/src/components/Layer.test.js
+++ b/src/components/Layer.test.js
@@ -11,12 +11,14 @@ const mockRemoveLayer = jest.fn((_key) => {});
 
 jest.mock('../services/neo4jService', () => {
   return {
-    getNeo4jDriver: jest.fn(() => Promise.resolve({})),
-    getNodeLabels: jest.fn((_driver) => Promise.resolve([])),
-    getProperties: jest.fn((_driver, _nodeFilter) => Promise.resolve([])),
-    hasSpatial: jest.fn((_driver) => Promise.resolve(false)),
-    getSpatialLayers: jest.fn((_driver) => Promise.resolve([])),
-    getData: jest.fn((_driver, _query, _params) => Promise.resolve([]))
+    neo4jService: {
+      getNeo4jDriver: jest.fn(() => Promise.resolve({})),
+      getNodeLabels: jest.fn((_driver) => Promise.resolve([])),
+      getProperties: jest.fn((_driver, _nodeFilter) => Promise.resolve([])),
+      hasSpatial: jest.fn((_driver) => Promise.resolve(false)),
+      getSpatialLayers: jest.fn((_driver) => Promise.resolve([])),
+      getData: jest.fn((_driver, _query, _params) => Promise.resolve([]))
+    }
   }
 });
 
@@ -25,7 +27,6 @@ const renderNewLayer = () => {
     <Layer
       key={NEW_LAYER.ukey}
       layer={NEW_LAYER}
-      driver={{}}
       addLayer={mockAddLayer}
       updateLayer={mockUpdateLayer}
       removeLayer={mockRemoveLayer}
@@ -209,7 +210,6 @@ describe('Test Layer component', () => {
       <Layer
         key={testLayer1.ukey}
         layer={testLayer1}
-        driver={{}}
         addLayer={mockAddLayer}
         updateLayer={mockUpdateLayer}
         removeLayer={mockRemoveLayer}

--- a/src/components/Layer.test.js
+++ b/src/components/Layer.test.js
@@ -12,7 +12,6 @@ const mockRemoveLayer = jest.fn((_key) => {});
 jest.mock('../services/neo4jService', () => {
   return {
     neo4jService: {
-      getNeo4jDriver: jest.fn(() => Promise.resolve({})),
       getNodeLabels: jest.fn(() => Promise.resolve({ status: 200, result: [] })),
       getProperties: jest.fn(( _nodeFilter) => Promise.resolve({ status: 200, result: [] })),
       hasSpatial: jest.fn(() => Promise.resolve({ status: 200, result: false })),

--- a/src/components/Layer.test.js
+++ b/src/components/Layer.test.js
@@ -13,11 +13,11 @@ jest.mock('../services/neo4jService', () => {
   return {
     neo4jService: {
       getNeo4jDriver: jest.fn(() => Promise.resolve({})),
-      getNodeLabels: jest.fn((_driver) => Promise.resolve([])),
-      getProperties: jest.fn((_driver, _nodeFilter) => Promise.resolve([])),
-      hasSpatial: jest.fn((_driver) => Promise.resolve(false)),
-      getSpatialLayers: jest.fn((_driver) => Promise.resolve([])),
-      getData: jest.fn((_driver, _query, _params) => Promise.resolve([]))
+      getNodeLabels: jest.fn(() => Promise.resolve({ status: 200, result: [] })),
+      getProperties: jest.fn(( _nodeFilter) => Promise.resolve({ status: 200, result: [] })),
+      hasSpatial: jest.fn(() => Promise.resolve({ status: 200, result: false })),
+      getSpatialLayers: jest.fn(() => Promise.resolve({ status: 200, result: [] })),
+      getData: jest.fn((_query, _params) => Promise.resolve({ status: 200, result: [] }))
     }
   }
 });

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -33,7 +33,8 @@ export const Map = React.memo(({layers}) => {
 			});
 		}
 
-	}, [mapElementRef]);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	React.useEffect(() => {
 		const map = mapRef.current;

--- a/src/components/SideBar.js
+++ b/src/components/SideBar.js
@@ -3,7 +3,7 @@ import Accordion from 'react-bootstrap/Accordion';
 import { Layer } from './Layer';
 import { NEW_LAYER } from './constants';
 
-export const SideBar = React.memo(({driver, layers, addLayer, updateLayer, removeLayer}) => {
+export const SideBar = React.memo(({ layers, addLayer, updateLayer, removeLayer }) => {
 
 	const renderLayers = () => {
 		return layers.map((layer) => {
@@ -12,7 +12,6 @@ export const SideBar = React.memo(({driver, layers, addLayer, updateLayer, remov
 					key={layer.ukey}
 					data-id="layers"
 					layer={layer}
-					driver={driver}
 					addLayer={addLayer}
 					updateLayer={updateLayer}
 					removeLayer={removeLayer}
@@ -28,7 +27,6 @@ export const SideBar = React.memo(({driver, layers, addLayer, updateLayer, remov
 				key={NEW_LAYER.ukey}
 				data-id="new-layer"
 				layer={NEW_LAYER}
-				driver={driver}
 				addLayer={addLayer}
 				updateLayer={updateLayer}
 				removeLayer={removeLayer}

--- a/src/components/SideBar.test.js
+++ b/src/components/SideBar.test.js
@@ -25,7 +25,6 @@ describe('SideBar tests', () => {
   it('always renders one create new layer', () => {
     const {container:sidebar, getByText} = render(
       <SideBar
-        driver={{}}
         layers={[]}
         addLayer={() => {}}
         updateLayer={() => {}}
@@ -40,7 +39,6 @@ describe('SideBar tests', () => {
   it('renders multiple layers and the create new layer', () => {
     const {container:sidebar, getByText} = render(
       <SideBar
-        driver={{}}
         layers={[ testLayer1, testLayer2 ]}
         addLayer={() => {}}
         updateLayer={() => {}}

--- a/src/services/neo4jService.js
+++ b/src/services/neo4jService.js
@@ -44,22 +44,10 @@ class Neo4JService {
     }
 
     const session = driver.session();
-
-    const records = await session.run(query, params).then(
-      (records) => records,
-      (error) => {
-        console.log(error);
-        return [];
-      }
-    );
-
+    const records = (await session.run(query, params)).records;
     session.close();
 
-    if (records && records.length > 0) {
-      return records;
-    } else {
-      throw new Error("No records found");
-    }
+    return records || [];
   };
 
   getNodeLabels = async () => {

--- a/src/services/neo4jService.js
+++ b/src/services/neo4jService.js
@@ -7,25 +7,12 @@ import neo4j from "neo4j-driver";
  */
 const neo4jDesktopApi = window.neo4jDesktopApi;
 
-/**
- * Returns a neo4j driver instance from the boltUrl, username, and passwords.
- *
- * Currently accepts bolt and bolt+routing
- * @param {String} boltUrl
- * @param {String} username
- * @param {String} password
- */
-const createDriver = (boltUrl, username, password) =>
-  neo4j.driver(boltUrl, neo4j.auth.basic(username, password));
-
 class Neo4JService {
   constructor() {
     this.driver = this.getNeo4jDriver();
   }
 
   getNeo4jDriver = async () => {
-    let driver = undefined;
-
     if (neo4jDesktopApi) {
       await neo4jDesktopApi.getContext().then((context) => {
         for (let project of context.projects) {
@@ -34,18 +21,23 @@ class Neo4JService {
               console.log(`Active graph is; ${graph.name} (${graph.description})`);
 
               let boltProtocol = graph.connection.configuration.protocols.bolt;
-              driver = createDriver(
+
+              const driver = neo4j.driver(
                 boltProtocol.url,
                 boltProtocol.username,
                 boltProtocol.password
               );
+
+              // Already found and athenticated an active graph.
+              // No need to try and authenticate other graphs.
+              return driver;
             }
           }
         }
       });
     }
 
-    return driver;
+    return undefined;
   };
 
   getNodeLabels = async () => {

--- a/src/services/neo4jService.test.js
+++ b/src/services/neo4jService.test.js
@@ -21,7 +21,7 @@ jest.mock('neo4j-driver', () => {
   const mockSession = {
     run: jest.fn((_query, _params, _config) => {
       return new Promise((resolve, _reject) => {
-        return resolve([mockRecord]);
+        return resolve({ records: [mockRecord] });
       });
     }),
     close: jest.fn()

--- a/src/services/neo4jService.test.js
+++ b/src/services/neo4jService.test.js
@@ -1,0 +1,139 @@
+import { neo4j } from 'neo4j-driver';
+import { neo4jService } from './neo4jService';
+
+const neo4jDesktopApiMock = {
+  getContext: jest.fn(() => {
+    const mockGraph = {
+      name: 'mock graph',
+      description: 'mock graph for testing',
+      connection: {
+        configuration: {
+          protocols: {
+            bolt: {
+              url: '',
+              username: '',
+              password: ''
+            }
+          }
+        }
+      }
+    }
+
+    const mockProject = {
+      graphs: [ mockGraph ]
+    }
+
+    const mockContext = {
+      projects: [ mockProject ]
+    }
+
+    return Promise.resolve(mockContext);
+  })
+}
+
+jest.mock('neo4j-driver', () => {
+  const mockSession = {
+    run: jest.fn(_query => []),
+    close: jest.fn()
+  }
+
+  const mockDriver = {
+    session: jest.fn(() => mockSession)
+  }
+
+  return {
+    neo4j: {
+      driver: jest.fn((_url, _username, _password) => mockDriver)
+    }
+  }
+});
+
+describe('neo4jService tests', () => {
+
+  it('can have an undefined driver', async () => {
+    // Act
+    const driver = await neo4jService._getNeo4jDriver();
+
+    // Assert
+    expect(driver).toBeUndefined()
+  });
+
+  it('returns error code 500 when driver is undefined', async () => {
+    // Arrange
+    const errorResult = { status: 500, error: new Error("Failed to get driver") };
+    const getDataCustomErrorResult = {
+      status:500,
+      error: new Error("Failed to get driver, please check your query")
+    };
+
+    // Act
+    const driver = await neo4jService._getNeo4jDriver();
+
+    // Assert
+    expect(driver).toBeUndefined()
+    expect(await neo4jService.getNodeLabels()).toEqual(errorResult);
+    expect(await neo4jService.getProperties()).toEqual(errorResult);
+    expect(await neo4jService.hasSpatial()).toEqual(errorResult);
+    expect(await neo4jService.getSpatialLayers()).toEqual(errorResult);
+    expect(await neo4jService.getData()).toEqual(getDataCustomErrorResult);
+  });
+
+  it('instantiates neo4jDesktop api', async () => {
+    // Arrange
+    // window.neo4jDesktopApi = neo4jDesktopApiMock;
+    // const mockDriver = await neo4j.driver();
+
+    // Act
+    // const driver = await neo4jService._getNeo4jDriver();
+
+    // Assert
+    // console.info(driver)
+    // expect(driver).toEqual(mockDriver);
+    expect(true); // FIXME
+  });
+
+  it('gets node labels', async () => {
+    // Arrange
+
+    // Act
+
+    // Assert
+    expect(true); // FIXME
+  });
+
+  it('gets properties', async () => {
+    // Arrange
+
+    // Act
+
+    // Assert
+    expect(true); // FIXME
+  });
+
+  it('checks for spatial', async () => {
+    // Arrange
+
+    // Act
+
+    // Assert
+    expect(true); // FIXME
+  });
+
+  it('gets spatial layers', async () => {
+    // Arrange
+
+    // Act
+
+    // Assert
+    expect(true); // FIXME
+  });
+
+  it('gets corect data', async () => {
+    // Arrange
+
+    // Act
+
+    // Assert
+    expect(true); // FIXME
+  });
+});

--- a/src/services/neo4jService.test.js
+++ b/src/services/neo4jService.test.js
@@ -32,7 +32,10 @@ jest.mock('neo4j-driver', () => {
   }
 
   return {
-    driver: jest.fn((_url, _authToken, _config) => mockDriver)
+    auth:  {
+      basic: (_username, _password, _realm=undefined) => 'AuthToken'
+    },
+    driver: jest.fn((_url, _authToken, _config) => mockDriver),
   }
 });
 

--- a/src/services/neo4jService.test.js
+++ b/src/services/neo4jService.test.js
@@ -1,139 +1,116 @@
-import { neo4j } from 'neo4j-driver';
+/**
+ * Importing neo4jDesktopApi from __mocks__ adds a mock desktop api to the global window object
+ * subsequent neo4jservice imports will use a mock api and driver *
+ */
+import '../../__mocks__/neo4jDesktopApi';
+
 import { neo4jService } from './neo4jService';
-
-const neo4jDesktopApiMock = {
-  getContext: jest.fn(() => {
-    const mockGraph = {
-      name: 'mock graph',
-      description: 'mock graph for testing',
-      connection: {
-        configuration: {
-          protocols: {
-            bolt: {
-              url: '',
-              username: '',
-              password: ''
-            }
-          }
-        }
-      }
-    }
-
-    const mockProject = {
-      graphs: [ mockGraph ]
-    }
-
-    const mockContext = {
-      projects: [ mockProject ]
-    }
-
-    return Promise.resolve(mockContext);
-  })
-}
+import { neo4jService as neo4jServiceCopy } from './neo4jService';
 
 jest.mock('neo4j-driver', () => {
+  const mockRecord = new Map([
+    ['name', 't-name'],
+    ['label', 't-label'],
+    ['layer', 't-layer'],
+    ['tooltip', 't-tooltip'],
+    ['propertyKey', 't-propertyKey'],
+    ['longitude', '4321'],
+    ['latitude', '1234']
+  ]);
+
   const mockSession = {
-    run: jest.fn(_query => []),
+    run: jest.fn((_query, _params, _config) => {
+      return new Promise((resolve, _reject) => {
+        return resolve([mockRecord]);
+      });
+    }),
     close: jest.fn()
   }
 
   const mockDriver = {
-    session: jest.fn(() => mockSession)
+    session: jest.fn((_args) => mockSession)
   }
 
   return {
-    neo4j: {
-      driver: jest.fn((_url, _username, _password) => mockDriver)
-    }
+    driver: jest.fn((_url, _authToken, _config) => mockDriver)
   }
 });
 
+
 describe('neo4jService tests', () => {
-
-  it('can have an undefined driver', async () => {
-    // Act
-    const driver = await neo4jService._getNeo4jDriver();
-
-    // Assert
-    expect(driver).toBeUndefined()
-  });
-
-  it('returns error code 500 when driver is undefined', async () => {
-    // Arrange
-    const errorResult = { status: 500, error: new Error("Failed to get driver") };
-    const getDataCustomErrorResult = {
-      status:500,
-      error: new Error("Failed to get driver, please check your query")
-    };
-
-    // Act
-    const driver = await neo4jService._getNeo4jDriver();
-
-    // Assert
-    expect(driver).toBeUndefined()
-    expect(await neo4jService.getNodeLabels()).toEqual(errorResult);
-    expect(await neo4jService.getProperties()).toEqual(errorResult);
-    expect(await neo4jService.hasSpatial()).toEqual(errorResult);
-    expect(await neo4jService.getSpatialLayers()).toEqual(errorResult);
-    expect(await neo4jService.getData()).toEqual(getDataCustomErrorResult);
-  });
-
-  it('instantiates neo4jDesktop api', async () => {
-    // Arrange
-    // window.neo4jDesktopApi = neo4jDesktopApiMock;
-    // const mockDriver = await neo4j.driver();
-
-    // Act
-    // const driver = await neo4jService._getNeo4jDriver();
-
-    // Assert
-    // console.info(driver)
-    // expect(driver).toEqual(mockDriver);
-    expect(true); // FIXME
+  it('is a singelton', () => {
+    expect(neo4jService).toEqual(neo4jServiceCopy);
   });
 
   it('gets node labels', async () => {
     // Arrange
+    const testNodeLabels = [
+      {
+        value: 't-label',
+        label: 't-label'
+      }
+    ]
 
     // Act
+    const nodeLabels = await neo4jService.getNodeLabels();
 
     // Assert
-    expect(true); // FIXME
+    expect(nodeLabels).toEqual({ status: 200, result: testNodeLabels });
   });
 
   it('gets properties', async () => {
     // Arrange
+    const testProperties = [
+      {
+        value: 't-propertyKey',
+        label: 't-propertyKey'
+      }
+    ]
 
     // Act
+    const properties = await neo4jService.getProperties();
 
     // Assert
-    expect(true); // FIXME
+    expect(properties).toEqual({ status: 200, result: testProperties });
   });
 
   it('checks for spatial', async () => {
-    // Arrange
-
     // Act
+    const hasSpatial = await neo4jService.hasSpatial()
 
     // Assert
-    expect(true); // FIXME
+    expect(hasSpatial).toEqual({ status: 200, result: true });
   });
 
   it('gets spatial layers', async () => {
     // Arrange
+    const testSpatialLayers = [
+      {
+        value: 't-layer',
+        label: 't-layer'
+      }
+    ]
 
     // Act
+    const spatialLayers = await neo4jService.getSpatialLayers();
 
     // Assert
-    expect(true); // FIXME
+    expect(spatialLayers).toEqual({ status: 200, result: testSpatialLayers });
   });
 
   it('gets corect data', async () => {
     // Arrange
+    const testData = [
+      {
+        pos: ['1234', '4321'],
+        tooltip: 't-tooltip'
+      }
+    ]
 
     // Act
+    const data = await neo4jService.getData();
 
     // Assert
-    expect(true); // FIXME
+    expect(data).toEqual({ status: 200, result: testData });
   });
 });


### PR DESCRIPTION
A singleton neo4jService that encapsulates driver. Layers don't need to have a knowledge of underlying neo4j driver. Composition proposed here allows us to smoothly swap out drivers in future #65, and remove driver instantiation on critical boot path #78.
Additionally, this PR formalizes a result API on neo4jService endpoints. Success from service calls return as `{ status: 200, result: someResult }` while failures return `{ status: 500, error: errorWithStack }`

Next: This pattern opens up an opportunity for better error ux, most immediately, a path for solving #77 [ don't rerender if we hit error on create/update new layer ]


PS: Builds on top of changes in PR #75 
