### PR TITLE
Feature/relationships

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -42,7 +42,6 @@ export class UnconnectedMap extends Component {
 		let ukeyPolylineArray = [];
 		let ukeyHeatmapArray = [];
 		let ukeyClusterArray = [];
-		// TODO
 		
 		// Iterate through layers
 		layers.map((layer) => {
@@ -70,7 +69,7 @@ export class UnconnectedMap extends Component {
 					// todo find a way of updating the polyline layer instead of delete & recreate
 					this.map.removeLayer(this.leafletPolylineLayers[layer.ukey]);
 				}
-				this.updateRelationsLayer(layer.data, layer.relations, layer.color, layer.ukey);
+				this.updateRelationsLayer(layer.data, layer.relationshipData, layer.color, layer.ukey);
 			} else if (layer.rendering === RENDERING_HEATMAP) {
 				ukeyHeatmapArray.push(layer.ukey);
 				if (this.leafletHeatmapLayers[layer.ukey]) {
@@ -192,12 +191,13 @@ export class UnconnectedMap extends Component {
 		// this.leafletPolylineLayers[ukey].setConfig??({ color });
 	}
 
-	updateRelationsLayer(data, relations_data, color, ukey) {
+	updateRelationsLayer(data, relationshipData, color, ukey) {
 		// todo check if the layer has changed before rerendering it
 		// this.leafletLayers[ukey].clearLayers();
 		let rgbColor = 'rgb(150, 150, 255)';
-		for (let i = 0; i < relations_data.length; i++) {
-			this.leafletPolylineLayers[ukey] = L.polyline([relations_data[i].start, relations_data[i].end], {color: rgbColor}).addTo(this.map);
+		console.log('HEY', relationshipData)
+		for (let i = 0; i < relationshipData.length; i++) {
+			this.leafletPolylineLayers[ukey] = L.polyline([relationshipData[i].start, relationshipData[i].end], {color: rgbColor}).addTo(this.map);
 		}
 		
 		// this.leafletPolylineLayers[ukey].clearLayers();

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -197,10 +197,30 @@ export class UnconnectedMap extends Component {
 		// todo check if the layer has changed before rerendering it
 		// this.leafletLayers[ukey].clearLayers();
 		let rgbColor = `rgb(${color.r}, ${color.g}, ${color.b})`;
-		
 		for (let i = 0; i < relations_data.length; i++) {
 			this.leafletPolylineLayers[ukey] = L.polyline([relations_data[i].start, relations_data[i].end], {color: rgbColor}).addTo(this.map);
 		}
+		
+		// this.leafletPolylineLayers[ukey].clearLayers();
+		let m = null;
+		data.forEach(entry => {
+			m = L.circleMarker(
+				entry.pos,
+				{
+					title: entry.tooltip,
+					fill: true,
+					radius: 2,
+					color: 'rgb(255, 0, 0)',
+					fillColor: rgbColor,
+					opacity: color.a,
+					fillOpacity: color.a
+				}
+			).addTo(this.map);
+			if (entry.tooltip !== undefined)
+				m.bindPopup(entry.tooltip);
+		});
+		
+		
 		// L.polyline(polylineData, {color: rgbColor}).addTo(this.map);
 		// this.leafletPolylineLayers[ukey].setLatLngs(polylineData);
 		// this.leafletPolylineLayers[ukey].setConfig??({ color });

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -71,7 +71,13 @@ export class UnconnectedMap extends Component {
 					// todo find a way of updating the polyline layer instead of delete & recreate
 					this.map.removeLayer(this.leafletRelationshipLayers[layer.ukey]);
 				}
-				this.updateRelationsLayer(layer.data, layer.relationshipData, layer.color, layer.ukey);
+				this.updateRelationsLayer(layer.data, layer.relationshipData, layer.relationshipColor, layer.ukey);
+				// have to use separate marker layer
+				ukeyMarkerArray.push(layer.ukey);
+				if (!this.leafletMarkerLayers[layer.ukey]) {
+					this.leafletMarkerLayers[layer.ukey] = L.layerGroup().addTo(this.map);
+				}
+				this.updateMarkerLayer(layer.data, layer.color, layer.ukey);
 			} else if (layer.rendering === RENDERING_HEATMAP) {
 				ukeyHeatmapArray.push(layer.ukey);
 				if (this.leafletHeatmapLayers[layer.ukey]) {
@@ -207,32 +213,13 @@ export class UnconnectedMap extends Component {
 	updateRelationsLayer(data, relationshipData, color, ukey) {
 		// todo check if the layer has changed before rerendering it
 		// this.leafletLayers[ukey].clearLayers();
-		let rgbColor = 'rgb(150, 150, 255)';
+		let rgbColor = `rgb(${color.r}, ${color.g}, ${color.b})`;
 		
 		let polylineData = relationshipData.map(part => [part.start, part.end]); // array of arrays does the trick
 		this.leafletRelationshipLayers[ukey] = L.polyline(polylineData, {color: rgbColor}).addTo(this.map);
 		
 		// this.leafletPolylineLayers[ukey].clearLayers();
-		let m = null;
-		data.forEach(entry => {
-			m = L.circleMarker(
-				entry.pos,
-				{
-					title: entry.tooltip,
-					fill: true,
-					radius: 2,
-					color: `rgb(${color.r}, ${color.g}, ${color.b})`,
-					fillColor: rgbColor,
-					opacity: color.a,
-					fillOpacity: color.a
-				}
-			).addTo(this.map);
-			if (entry.tooltip !== undefined)
-				m.bindPopup(entry.tooltip);
-		});
-		
-		
-		// L.polyline(polylineData, {color: rgbColor}).addTo(this.map);
+        // L.polyline(polylineData, {color: rgbColor}).addTo(this.map);
 		// this.leafletPolylineLayers[ukey].setLatLngs(polylineData);
 		// this.leafletPolylineLayers[ukey].setConfig??({ color });
 	}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -46,7 +46,6 @@ export class UnconnectedMap extends Component {
 		
 		// Iterate through layers
 		layers.map((layer) => {
-			layer.rendering = RENDERING_RELATIONS
 			if (layer.ukey === undefined)
 				return null;
 			let bds = new L.LatLngBounds(layer.bounds);
@@ -196,7 +195,7 @@ export class UnconnectedMap extends Component {
 	updateRelationsLayer(data, relations_data, color, ukey) {
 		// todo check if the layer has changed before rerendering it
 		// this.leafletLayers[ukey].clearLayers();
-		let rgbColor = `rgb(${color.r}, ${color.g}, ${color.b})`;
+		let rgbColor = 'rgb(150, 150, 255)';
 		for (let i = 0; i < relations_data.length; i++) {
 			this.leafletPolylineLayers[ukey] = L.polyline([relations_data[i].start, relations_data[i].end], {color: rgbColor}).addTo(this.map);
 		}
@@ -210,7 +209,7 @@ export class UnconnectedMap extends Component {
 					title: entry.tooltip,
 					fill: true,
 					radius: 2,
-					color: 'rgb(255, 0, 0)',
+					color: `rgb(${color.r}, ${color.g}, ${color.b})`,
 					fillColor: rgbColor,
 					opacity: color.a,
 					fillOpacity: color.a

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -4,7 +4,7 @@
  */
 import React, {Component} from 'react'
 import {connect} from 'react-redux';
-import {RENDERING_CLUSTERS, RENDERING_HEATMAP, RENDERING_MARKERS, RENDERING_POLYLINE} from "./layers/Layer";
+import {RENDERING_CLUSTERS, RENDERING_HEATMAP, RENDERING_MARKERS, RENDERING_POLYLINE, RENDERING_RELATIONS} from "./layers/Layer";
 import L from 'leaflet';
 import 'leaflet.heat';
 import 'leaflet.markercluster';
@@ -42,8 +42,11 @@ export class UnconnectedMap extends Component {
 		let ukeyPolylineArray = [];
 		let ukeyHeatmapArray = [];
 		let ukeyClusterArray = [];
+		// TODO
+		
 		// Iterate through layers
 		layers.map((layer) => {
+			layer.rendering = RENDERING_RELATIONS
 			if (layer.ukey === undefined)
 				return null;
 			let bds = new L.LatLngBounds(layer.bounds);
@@ -62,6 +65,13 @@ export class UnconnectedMap extends Component {
 					this.map.removeLayer(this.leafletPolylineLayers[layer.ukey]);
 				}
 				this.updatePolylineLayer(layer.data, layer.color, layer.ukey);
+			} else if (layer.rendering === RENDERING_RELATIONS) {
+				ukeyPolylineArray.push(layer.ukey);
+				if (this.leafletPolylineLayers[layer.ukey]) {
+					// todo find a way of updating the polyline layer instead of delete & recreate
+					this.map.removeLayer(this.leafletPolylineLayers[layer.ukey]);
+				}
+				this.updateRelationsLayer(layer.data, layer.relations, layer.color, layer.ukey);
 			} else if (layer.rendering === RENDERING_HEATMAP) {
 				ukeyHeatmapArray.push(layer.ukey);
 				if (this.leafletHeatmapLayers[layer.ukey]) {
@@ -179,6 +189,19 @@ export class UnconnectedMap extends Component {
 			return entry.pos;
 		});
 		this.leafletPolylineLayers[ukey] = L.polyline(polylineData, {color: rgbColor}).addTo(this.map);
+		// this.leafletPolylineLayers[ukey].setLatLngs(polylineData);
+		// this.leafletPolylineLayers[ukey].setConfig??({ color });
+	}
+
+	updateRelationsLayer(data, relations_data, color, ukey) {
+		// todo check if the layer has changed before rerendering it
+		// this.leafletLayers[ukey].clearLayers();
+		let rgbColor = `rgb(${color.r}, ${color.g}, ${color.b})`;
+		
+		for (let i = 0; i < relations_data.length; i++) {
+			this.leafletPolylineLayers[ukey] = L.polyline([relations_data[i].start, relations_data[i].end], {color: rgbColor}).addTo(this.map);
+		}
+		// L.polyline(polylineData, {color: rgbColor}).addTo(this.map);
 		// this.leafletPolylineLayers[ukey].setLatLngs(polylineData);
 		// this.leafletPolylineLayers[ukey].setConfig??({ color });
 	}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -29,6 +29,7 @@ export class UnconnectedMap extends Component {
 
 		this.leafletMarkerLayers = {};
 		this.leafletPolylineLayers = {};
+		this.leafletRelationshipLayers = {};
 		this.leafletHeatmapLayers = {};
 		this.leafletClusterLayers = {};
 		this.layerControl = null;
@@ -40,6 +41,7 @@ export class UnconnectedMap extends Component {
 		let globalBounds = new L.LatLngBounds();
 		let ukeyMarkerArray = [];
 		let ukeyPolylineArray = [];
+		let ukeyRelationshipArray = [];
 		let ukeyHeatmapArray = [];
 		let ukeyClusterArray = [];
 		
@@ -64,10 +66,10 @@ export class UnconnectedMap extends Component {
 				}
 				this.updatePolylineLayer(layer.data, layer.color, layer.ukey);
 			} else if (layer.rendering === RENDERING_RELATIONS) {
-				ukeyPolylineArray.push(layer.ukey);
-				if (this.leafletPolylineLayers[layer.ukey]) {
+				ukeyRelationshipArray.push(layer.ukey);
+				if (this.leafletRelationshipLayers[layer.ukey]) {
 					// todo find a way of updating the polyline layer instead of delete & recreate
-					this.map.removeLayer(this.leafletPolylineLayers[layer.ukey]);
+					this.map.removeLayer(this.leafletRelationshipLayers[layer.ukey]);
 				}
 				this.updateRelationsLayer(layer.data, layer.relationshipData, layer.color, layer.ukey);
 			} else if (layer.rendering === RENDERING_HEATMAP) {
@@ -105,6 +107,14 @@ export class UnconnectedMap extends Component {
 		deletedPolylineUkeyLayers.map((key) => {
 			this.map.removeLayer(this.leafletPolylineLayers[key]);
 			delete this.leafletPolylineLayers[key];
+			return null;
+		});
+		let deletedRelationshipUkeyLayers = Object.keys(this.leafletRelationshipLayers).filter(function (key) {
+			return !ukeyRelationshipArray.includes(key);
+		});
+		deletedRelationshipUkeyLayers.map((key) => {
+			this.map.removeLayer(this.leafletRelationshipLayers[key]);
+			delete this.leafletRelationshipLayers[key];
 			return null;
 		});
 		let deletedHeatmapUkeyLayers = Object.keys(this.leafletHeatmapLayers).filter(function (key) {
@@ -145,6 +155,9 @@ export class UnconnectedMap extends Component {
 					break;
 				case RENDERING_POLYLINE:
 					overlayMaps[l.name] = this.leafletPolylineLayers[l.ukey];
+					break;
+				case RENDERING_RELATIONS:
+					overlayMaps[l.name] = this.leafletRelationshipLayers[l.ukey];
 					break;
 				default:
 					break;
@@ -195,10 +208,9 @@ export class UnconnectedMap extends Component {
 		// todo check if the layer has changed before rerendering it
 		// this.leafletLayers[ukey].clearLayers();
 		let rgbColor = 'rgb(150, 150, 255)';
-		console.log('HEY', relationshipData)
-		for (let i = 0; i < relationshipData.length; i++) {
-			this.leafletPolylineLayers[ukey] = L.polyline([relationshipData[i].start, relationshipData[i].end], {color: rgbColor}).addTo(this.map);
-		}
+		
+		let polylineData = relationshipData.map(part => [part.start, part.end]); // array of arrays does the trick
+		this.leafletRelationshipLayers[ukey] = L.polyline(polylineData, {color: rgbColor}).addTo(this.map);
 		
 		// this.leafletPolylineLayers[ukey].clearLayers();
 		let m = null;

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -40,14 +40,15 @@ export const RENDERING_CLUSTERS = "clusters";
 const DEFAULT_LAYER = {
 	name: "New layer",
 	layerType: LAYER_TYPE_LATLON,
-	latitudeProperty: {value: "latitude", label: "latitude"},
-	longitudeProperty: {value: "longitude", label: "longitude"},
+	latitudeProperty: {value: "lat", label: "lat"},
+	longitudeProperty: {value: "lon", label: "lon"},
 	pointProperty: {value: "point", label: "point"},
 	tooltipProperty: {value: "", label: ""},
 	nodeLabel: [],
 	propertyNames: [],
 	spatialLayers: [],
 	data: [],
+	relations: [],
 	bounds: [],
 	color: {r: 0, g: 0, b: 255, a: 1},
 	limit: null,
@@ -100,6 +101,7 @@ export class UnconnectedLayer extends Component {
 		this.getPropertyNames();
 		this.hasSpatialPlugin();
 		this.getSpatialLayers();
+		this.getRelations();
 	}
 
 
@@ -210,9 +212,27 @@ export class UnconnectedLayer extends Component {
 		// limit the number of points to avoid browser crash...
 		if (this.state.limit)
 			query += `\nLIMIT ${this.state.limit}`;
-
+		console.log(query)
 		return query;
 	};
+
+	getRelations() {
+		const query = "match ()-[r]->() return r";
+		neo4jService.getRelationData(this.driver, query, {}).then( res => {
+			if (res.status === "ERROR") {
+				let message = "Invalid cypher query.";
+				if (this.state.layerType !== LAYER_TYPE_CYPHER) {
+					message += "\nContact the development team";
+				} else {
+					message += "\nFix your query and try again";
+				}
+				message += "\n\n" + res.result;
+				alert(message);
+			} else {
+				this.setState({relations: res.result}, () => console.log('yo', res.result));
+			}
+		});
+	}
 
 
 	updateData() {

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -41,8 +41,8 @@ export const RENDERING_CLUSTERS = "clusters";
 const DEFAULT_LAYER = {
 	name: "New layer",
 	layerType: LAYER_TYPE_LATLON,
-	latitudeProperty: {value: "lat", label: "lat"},
-	longitudeProperty: {value: "lon", label: "lon"},
+	latitudeProperty: {value: "latitude", label: "latitude"},
+	longitudeProperty: {value: "longitude", label: "longitude"},
 	pointProperty: {value: "point", label: "point"},
 	tooltipProperty: {value: "", label: ""},
 	relationshipTooltipProperty: {value: "", label: ""},

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -258,10 +258,6 @@ export class UnconnectedLayer extends Component {
 		return this.getNodesQuery();		
 	};
 
-	getRelationshipTypes() {
-		const query = "CALL db.relationshipTypes()"
-	}
-
 	getRelationshipsQuery() {
 		// SUPPORTS ONLY LAT LON FOR NOW
 		const { value: latValue } = this.state.latitudeProperty;

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -652,8 +652,7 @@ export class UnconnectedLayer extends Component {
 						name="nodeLabel"
 					/>
 				</Form.Group>
-				{/* TODO MOVE */}
-				<Form.Group controlId="formRelationshipLabel" hidden={rendering !== RENDERING_RELATIONS }>
+				<Form.Group controlId="formRelationshipLabel" hidden={ rendering !== RENDERING_RELATIONS }>
 					<Form.Label>Relationship label(s)</Form.Label>
 					<Select
 						className="form-control select"

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -710,7 +710,7 @@ export class UnconnectedLayer extends Component {
 
 				<Form.Group 
 					controlId="formRelationshipTooltipProperty" 
-					hidden={ rendering !== RENDERING_RELATIONS }  
+					hidden={true}  // TODO figure out how to display tooltip at polyline
 					name="formgroupRelationshipTooltip"
 				>
 					<Form.Label>Relationship Tooltip property</Form.Label>
@@ -719,7 +719,6 @@ export class UnconnectedLayer extends Component {
 						options={propertyNames}
 						onChange={this.handleRelationshipTooltipPropertyChange}
 						isMulti={false}
-						hidden={true}  // TODO figure out how to display tooltip at polyline
 						defaultValue={relationshipTooltipProperty}
 						name="relationshipTooltipProperty"
 					/>

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -32,6 +32,7 @@ const LAYER_TYPE_SPATIAL = "spatial";
 // TODO: move this into a separate configuration/constants file
 export const RENDERING_MARKERS = "markers";
 export const RENDERING_POLYLINE = "polyline";
+export const RENDERING_RELATIONS = "relations";
 export const RENDERING_HEATMAP = "heatmap";
 export const RENDERING_CLUSTERS = "clusters";
 
@@ -217,7 +218,7 @@ export class UnconnectedLayer extends Component {
 	};
 
 	getRelations() {
-		const query = "match ()-[r]->() return r";
+		const query = "match (n)-[r]->(m) return n.lat as start_lat, n.lon as start_lon, m.lat as end_lat, m.lon as end_lon;";
 		neo4jService.getRelationData(this.driver, query, {}).then( res => {
 			if (res.status === "ERROR") {
 				let message = "Invalid cypher query.";

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -55,6 +55,7 @@ const DEFAULT_LAYER = {
 	relationships: [],
 	bounds: [],
 	color: {r: 0, g: 0, b: 255, a: 1},
+	relationshipColor: {r: 0, g: 0, b: 255, a: 1},
 	limit: null,
 	rendering: RENDERING_MARKERS,
 	radius: 30,
@@ -93,6 +94,7 @@ export class UnconnectedLayer extends Component {
 		this.handleRelationshipTooltipPropertyChange = this.handleRelationshipTooltipPropertyChange.bind(this);
 		this.handleLimitChange = this.handleLimitChange.bind(this);
 		this.handleColorChange = this.handleColorChange.bind(this);
+		this.handleRelationshipColorChange = this.handleRelationshipColorChange.bind(this);
 		this.handleRenderingChange = this.handleRenderingChange.bind(this);
 		this.handleRadiusChange = this.handleRadiusChange.bind(this);
 		this.handleCypherChange = this.handleCypherChange.bind(this);
@@ -253,8 +255,6 @@ export class UnconnectedLayer extends Component {
 
 		if (layerType === LAYER_TYPE_SPATIAL)
 			return this.getSpatialQuery();
-		const rel_q = this.getRelationshipsQuery();
-		console.log("REL QUERY!", rel_q);
 		return this.getNodesQuery();		
 	};
 
@@ -289,22 +289,6 @@ export class UnconnectedLayer extends Component {
 			query += `\nLIMIT ${limit}`;
 		console.log(query)
 		return query;
-
-		// const query = "match (n)-[r]->(m) return n.lat as start_lat, n.lon as start_lon, m.lat as end_lat, m.lon as end_lon;";
-		// neo4jService.getRelationData(this.driver, query, {}).then( res => {
-		// 	if (res.status === "ERROR") {
-		// 		let message = "Invalid cypher query.";
-		// 		if (this.state.layerType !== LAYER_TYPE_CYPHER) {
-		// 			message += "\nContact the development team";
-		// 		} else {
-		// 			message += "\nFix your query and try again";
-		// 		}
-		// 		message += "\n\n" + res.result;
-		// 		alert(message);
-		// 	} else {
-		// 		this.setState({relations: res.result}, () => console.log('yo', res.result));
-		// 	}
-		// });
 	}
 
 
@@ -338,7 +322,6 @@ export class UnconnectedLayer extends Component {
 					message += "\n\n" + res.result;
 					alert(message);
 				} else {
-					console.log("GOT RES", res)
 					this.setState({relationshipData: res.result}, this.updateBounds);
 				}
 			});
@@ -416,6 +399,12 @@ export class UnconnectedLayer extends Component {
 	handleColorChange(color) {
 		this.setState({
 			color: color,
+		});
+	};
+
+	handleRelationshipColorChange(color) {
+		this.setState({
+			relationshipColor: color,
 		});
 	};
 
@@ -654,7 +643,6 @@ export class UnconnectedLayer extends Component {
 		} = this.state;
 		if (layerType !== LAYER_TYPE_LATLON)
 			return "";
-		console.log(rendering, RENDERING_RELATIONS)
 		return (
 			<div>
 				<Form.Group controlId="formNodeLabel">
@@ -731,6 +719,7 @@ export class UnconnectedLayer extends Component {
 						options={propertyNames}
 						onChange={this.handleRelationshipTooltipPropertyChange}
 						isMulti={false}
+						hidden={true}  // TODO figure out how to display tooltip at polyline
 						defaultValue={relationshipTooltipProperty}
 						name="relationshipTooltipProperty"
 					/>
@@ -753,7 +742,7 @@ export class UnconnectedLayer extends Component {
 
 
 	render() {
-		const { name, ukey, rendering, layerType, hasSpatialPlugin, color, 
+		const { name, ukey, rendering, layerType, hasSpatialPlugin, color, relationshipColor,
 			radius,
 		} = this.state;
 		const colorString = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`;
@@ -899,6 +888,16 @@ export class UnconnectedLayer extends Component {
 								<ColorPicker
 									color={ color }
 									handleColorChange={this.handleColorChange}
+								/>
+							</Form.Group>
+
+							<Form.Group controlId="formRelationshipColor"
+										hidden={rendering !== RENDERING_RELATIONS}
+										name="formgroupRelationshipColor">
+								<Form.Label>Relationship Color</Form.Label>
+								<ColorPicker
+									color={ relationshipColor }
+									handleColorChange={this.handleRelationshipColorChange}
 								/>
 							</Form.Group>
 

--- a/src/components/layers/Layer.js
+++ b/src/components/layers/Layer.js
@@ -323,7 +323,7 @@ export class UnconnectedLayer extends Component {
 				message += "\n\n" + res.result;
 				alert(message);
 			} else {
-				this.setState({data: res.result}, this.updateBounds);
+				this.setState({data: res.result}, () => {if (rendering !== RENDERING_RELATIONS) {this.updateBounds()}});
 			}
 		});
 		if (rendering === RENDERING_RELATIONS) {
@@ -339,7 +339,7 @@ export class UnconnectedLayer extends Component {
 					alert(message);
 				} else {
 					console.log("GOT RES", res)
-					this.setState({relationshipData: res.result}, () => console.log('argh', this.state.relationshipData));
+					this.setState({relationshipData: res.result}, this.updateBounds);
 				}
 			});
 		}

--- a/src/services/neo4jService.js
+++ b/src/services/neo4jService.js
@@ -175,7 +175,6 @@ export default {
               result: query,
             };
           }
-          console.log("NODES", response)
           response.records.forEach((record) => {
             let el = {
               pos: [record.get("latitude"), record.get("longitude")],
@@ -197,7 +196,7 @@ export default {
         });
         
   },
-  getRelationData: async function (driver, query, params) {
+  getRelationshipData: async function (driver, query, params) {
     const session = driver.session();
     return await session
         .run(query, params)
@@ -212,8 +211,8 @@ export default {
           }
           response.records.forEach((record) => {
             let el = {
-              start: [record.get("start_latitude"), record.get("start_longtitude")],
-              end: [record.get("end_latitude"), record.get("end_longtitude")],
+              start: [record.get("start_latitude"), record.get("start_longitude")],
+              end: [record.get("end_latitude"), record.get("end_longitude")],
             };
             if (record.has("tooltip") && record.get("tooltip") != null) {
               // make sure tooltip is a string, otherwise leaflet is not happy AT ALL!

--- a/src/services/neo4jService.js
+++ b/src/services/neo4jService.js
@@ -199,7 +199,8 @@ export default {
           }
           response.records.forEach((record) => {
             let el = {
-              nodes: [Number(record._fields[0].start), Number(record._fields[0].end)],
+              start: [record.get("start_lat"), record.get("start_lon")],
+              end: [record.get("end_lat"), record.get("end_lon")],
             };
             if (record.has("tooltip") && record.get("tooltip") !== null) {
               // make sure tooltip is a string, otherwise leaflet is not happy AT ALL!

--- a/src/services/neo4jService.js
+++ b/src/services/neo4jService.js
@@ -53,7 +53,7 @@ export default {
     let res = [];
     const session = driver.session();
     await session
-      .run(`CALL db.labels() YIELD label RETURN label ORDER BY label`)
+      .run('CALL db.labels() YIELD label RETURN label ORDER BY label')
       .then(function (result) {
         result.records.forEach(function (record) {
           let el = {
@@ -68,6 +68,19 @@ export default {
         console.log(error);
       });
 
+    return res;
+  },
+
+  getRelationshipLabels: async function (driver) {
+    if (driver == null) return [];
+
+    const session = driver.session();
+    const result = await session.run('CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType ORDER BY relationshipType;')
+    const res = result.records.map(record => ({
+            value: record.get("relationshipType"),
+            label: record.get("relationshipType"),
+          }));    
+    session.close();
     return res;
   },
 
@@ -199,10 +212,10 @@ export default {
           }
           response.records.forEach((record) => {
             let el = {
-              start: [record.get("start_lat"), record.get("start_lon")],
-              end: [record.get("end_lat"), record.get("end_lon")],
+              start: [record.get("start_latitude"), record.get("start_longtitude")],
+              end: [record.get("end_latitude"), record.get("end_longtitude")],
             };
-            if (record.has("tooltip") && record.get("tooltip") !== null) {
+            if (record.has("tooltip") && record.get("tooltip") != null) {
               // make sure tooltip is a string, otherwise leaflet is not happy AT ALL!
               el["tooltip"] = record.get("tooltip").toString();
             }

--- a/src/services/neo4jService.js
+++ b/src/services/neo4jService.js
@@ -162,6 +162,7 @@ export default {
               result: query,
             };
           }
+          console.log("NODES", response)
           response.records.forEach((record) => {
             let el = {
               pos: [record.get("latitude"), record.get("longitude")],
@@ -181,5 +182,39 @@ export default {
         .catch((error) => {
           return {status: "ERROR", result: error};
         });
+        
   },
+  getRelationData: async function (driver, query, params) {
+    const session = driver.session();
+    return await session
+        .run(query, params)
+        .then((response) => {
+          let res = [];
+          if (response.records === undefined || response.records.length === 0) {
+            alert("No result found, please check your query");
+            return {
+              status: "ERROR",
+              result: query,
+            };
+          }
+          response.records.forEach((record) => {
+            let el = {
+              nodes: [Number(record._fields[0].start), Number(record._fields[0].end)],
+            };
+            if (record.has("tooltip") && record.get("tooltip") !== null) {
+              // make sure tooltip is a string, otherwise leaflet is not happy AT ALL!
+              el["tooltip"] = record.get("tooltip").toString();
+            }
+            res.push(el);
+          });
+          session.close();
+          return {
+            status: "OK",
+            result: res,
+          };
+        })
+        .catch((error) => {
+          return {status: "ERROR", result: error};
+        });
+      }
 };


### PR DESCRIPTION
closes issue #15 

- added query to get relationships. supports filtering by node labels and relationship type
- saving relationships data in a separate state variable. Thought about saving only relationships data and displaying nodes using start/end points but generally we may have nodes that are disconnected and it is helpful to be able to display them
- added color picker for relationships
- made almost everything to display tooltips for relationships but haven't figured out how to apply this to polyline :disappointed: 
- added js destructuring assignments at some places to make code a bit better

Example with a fragment of Saint Petersburg:
![image](https://user-images.githubusercontent.com/33401112/120922594-bd856580-c6d2-11eb-9427-c250446f96af.png)

