### PR TITLE
Feature/geoman

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1386,6 +1386,19 @@
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
 			"integrity": "sha1-ju2YLi7m9/TkTCU+EpYpgHke/UY="
 		},
+		"@geoman-io/leaflet-geoman-free": {
+			"version": "2.11.2",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@geoman-io/leaflet-geoman-free/-/leaflet-geoman-free-2.11.2.tgz",
+			"integrity": "sha1-4lmLNmfVCZxo48MjpqCQ87yfCyY=",
+			"requires": {
+				"@turf/boolean-contains": "6.3.0",
+				"@turf/kinks": "6.3.0",
+				"@turf/line-intersect": "6.3.0",
+				"@turf/line-split": "6.3.0",
+				"lodash": "4.17.21",
+				"polygon-clipping": "0.15.3"
+			}
+		},
 		"@hapi/address": {
 			"version": "2.1.4",
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@hapi/address/-/address-2.1.4.tgz",
@@ -1998,6 +2011,186 @@
 				"@testing-library/dom": "^7.22.3"
 			}
 		},
+		"@turf/bbox": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/bbox/-/bbox-6.5.0.tgz",
+			"integrity": "sha1-vsMKdEAZ6uQg2snqRvt1yqRNjcU=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			}
+		},
+		"@turf/bearing": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/bearing/-/bearing-6.5.0.tgz",
+			"integrity": "sha1-RioFPGxkRDS9tjazn49D+wzYV7A=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			}
+		},
+		"@turf/boolean-contains": {
+			"version": "6.3.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/boolean-contains/-/boolean-contains-6.3.0.tgz",
+			"integrity": "sha1-/k/DWeQIyMPInn+xWcnTH95Id5o=",
+			"requires": {
+				"@turf/bbox": "^6.3.0",
+				"@turf/boolean-point-in-polygon": "^6.3.0",
+				"@turf/boolean-point-on-line": "^6.3.0",
+				"@turf/helpers": "^6.3.0",
+				"@turf/invariant": "^6.3.0"
+			}
+		},
+		"@turf/boolean-point-in-polygon": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
+			"integrity": "sha1-bS6cid5M0uQ2UATB5RSQt3laY88=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			}
+		},
+		"@turf/boolean-point-on-line": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/boolean-point-on-line/-/boolean-point-on-line-6.5.0.tgz",
+			"integrity": "sha1-qO+nutiHYGdvOVr7mYB0a8Wzduk=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			}
+		},
+		"@turf/destination": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/destination/-/destination-6.5.0.tgz",
+			"integrity": "sha1-MKhHAvlnfQdhMOBEDTIjrlA/2uE=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			}
+		},
+		"@turf/distance": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/distance/-/distance-6.5.0.tgz",
+			"integrity": "sha1-IfBNX4boZNVOKr3hbzXBW082FJo=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0"
+			}
+		},
+		"@turf/helpers": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/helpers/-/helpers-6.5.0.tgz",
+			"integrity": "sha1-95rwlL1rjOftK9PgiahJPubK6C4="
+		},
+		"@turf/invariant": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/invariant/-/invariant-6.5.0.tgz",
+			"integrity": "sha1-lwr8mIAj45x8yrI0G9Bped3HRj8=",
+			"requires": {
+				"@turf/helpers": "^6.5.0"
+			}
+		},
+		"@turf/kinks": {
+			"version": "6.3.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/kinks/-/kinks-6.3.0.tgz",
+			"integrity": "sha1-oWtMzFparhOdQ+NiceCgSU/bS/c=",
+			"requires": {
+				"@turf/helpers": "^6.3.0"
+			}
+		},
+		"@turf/line-intersect": {
+			"version": "6.3.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/line-intersect/-/line-intersect-6.3.0.tgz",
+			"integrity": "sha1-cmpQ7cZrt7XnmLBSsQP7DaTRxPQ=",
+			"requires": {
+				"@turf/helpers": "^6.3.0",
+				"@turf/invariant": "^6.3.0",
+				"@turf/line-segment": "^6.3.0",
+				"@turf/meta": "^6.3.0",
+				"geojson-rbush": "3.x"
+			}
+		},
+		"@turf/line-segment": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/line-segment/-/line-segment-6.5.0.tgz",
+			"integrity": "sha1-7nPz/8t8lWIDtk7ZZtlq84Ck3WU=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			}
+		},
+		"@turf/line-split": {
+			"version": "6.3.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/line-split/-/line-split-6.3.0.tgz",
+			"integrity": "sha1-7iGPZs1lzoTq/ElWwkCDZj9gguo=",
+			"requires": {
+				"@turf/bbox": "^6.3.0",
+				"@turf/helpers": "^6.3.0",
+				"@turf/invariant": "^6.3.0",
+				"@turf/line-intersect": "^6.3.0",
+				"@turf/line-segment": "^6.3.0",
+				"@turf/meta": "^6.3.0",
+				"@turf/nearest-point-on-line": "^6.3.0",
+				"@turf/square": "^6.3.0",
+				"@turf/truncate": "^6.3.0",
+				"geojson-rbush": "3.x"
+			}
+		},
+		"@turf/meta": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/meta/-/meta-6.5.0.tgz",
+			"integrity": "sha1-tyXDZTyfQyEz6qBNNCH35R4EGMo=",
+			"requires": {
+				"@turf/helpers": "^6.5.0"
+			}
+		},
+		"@turf/nearest-point-on-line": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/nearest-point-on-line/-/nearest-point-on-line-6.5.0.tgz",
+			"integrity": "sha1-jhzSzcC1rK9MjYs7M7sAjTy5nns=",
+			"requires": {
+				"@turf/bearing": "^6.5.0",
+				"@turf/destination": "^6.5.0",
+				"@turf/distance": "^6.5.0",
+				"@turf/helpers": "^6.5.0",
+				"@turf/invariant": "^6.5.0",
+				"@turf/line-intersect": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			},
+			"dependencies": {
+				"@turf/line-intersect": {
+					"version": "6.5.0",
+					"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
+					"integrity": "sha1-3qSDSLMMCTcV0hldLddSSu5M8CA=",
+					"requires": {
+						"@turf/helpers": "^6.5.0",
+						"@turf/invariant": "^6.5.0",
+						"@turf/line-segment": "^6.5.0",
+						"@turf/meta": "^6.5.0",
+						"geojson-rbush": "3.x"
+					}
+				}
+			}
+		},
+		"@turf/square": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/square/-/square-6.5.0.tgz",
+			"integrity": "sha1-q0Pu+Z05w2FXq1uAQWu+uh9rISI=",
+			"requires": {
+				"@turf/distance": "^6.5.0",
+				"@turf/helpers": "^6.5.0"
+			}
+		},
+		"@turf/truncate": {
+			"version": "6.5.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@turf/truncate/-/truncate-6.5.0.tgz",
+			"integrity": "sha1-w6FsrZWfG+HFFWFX1VVcZLGRhdg=",
+			"requires": {
+				"@turf/helpers": "^6.5.0",
+				"@turf/meta": "^6.5.0"
+			}
+		},
 		"@types/aria-query": {
 			"version": "4.2.2",
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -2045,6 +2238,11 @@
 			"version": "1.0.0",
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
 			"integrity": "sha1-HuMNeVRMqE1o1LPNsK9PIFZj3S0="
+		},
+		"@types/geojson": {
+			"version": "7946.0.8",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/@types/geojson/-/geojson-7946.0.8.tgz",
+			"integrity": "sha1-MHRK/bOF4pReIvOwM/iX92sfEso="
 		},
 		"@types/glob": {
 			"version": "7.1.4",
@@ -7026,6 +7224,18 @@
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA="
 		},
+		"geojson-rbush": {
+			"version": "3.2.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
+			"integrity": "sha1-i1Q88NVvmbePrx2lK7ZqytbfwpA=",
+			"requires": {
+				"@turf/bbox": "*",
+				"@turf/helpers": "6.x",
+				"@turf/meta": "6.x",
+				"@types/geojson": "7946.0.8",
+				"rbush": "^3.0.1"
+			}
+		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -10371,6 +10581,14 @@
 				"ts-pnp": "^1.1.6"
 			}
 		},
+		"polygon-clipping": {
+			"version": "0.15.3",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/polygon-clipping/-/polygon-clipping-0.15.3.tgz",
+			"integrity": "sha1-AhWEBDhHC6Lp5lk2JeTqXBCHtLc=",
+			"requires": {
+				"splaytree": "^3.1.0"
+			}
+		},
 		"portfinder": {
 			"version": "1.0.28",
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/portfinder/-/portfinder-1.0.28.tgz",
@@ -11524,6 +11742,11 @@
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/querystringify/-/querystringify-2.2.0.tgz",
 			"integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y="
 		},
+		"quickselect": {
+			"version": "2.0.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/quickselect/-/quickselect-2.0.0.tgz",
+			"integrity": "sha1-8ZaApIal7vtYEwPgI+mPqvJd0Bg="
+		},
 		"raf": {
 			"version": "3.4.1",
 			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/raf/-/raf-3.4.1.tgz",
@@ -11578,6 +11801,14 @@
 						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				}
+			}
+		},
+		"rbush": {
+			"version": "3.0.1",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/rbush/-/rbush-3.0.1.tgz",
+			"integrity": "sha1-X6+op5s7mv3+UAhAOnIMwd6ILs8=",
+			"requires": {
+				"quickselect": "^2.0.0"
 			}
 		},
 		"react": {
@@ -13233,6 +13464,11 @@
 					}
 				}
 			}
+		},
+		"splaytree": {
+			"version": "3.1.0",
+			"resolved": "https://neo.jfrog.io/neo/api/npm/npm/splaytree/-/splaytree-3.1.0.tgz",
+			"integrity": "sha1-F9SgEIpto2J1eWkLe4RyQeGN3sg="
 		},
 		"split-string": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"licenseRequired": false
 	},
 	"dependencies": {
+		"@geoman-io/leaflet-geoman-free": "^2.11.2",
 		"bootstrap": "^4.5.2",
 		"downloadjs": "^1.4.7",
 		"graph-app-kit": "^1.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 
-    <head>
+<head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<meta name="theme-color" content="#000000">
@@ -11,27 +11,28 @@
 
 	<!-- Leaflet -->
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.5.1/dist/leaflet.css"
-	      integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
-	      crossorigin=""/>
+		integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ=="
+		crossorigin="" />
 	<!-- Make sure you put this AFTER Leaflet's CSS -->
 	<script src="https://unpkg.com/leaflet@1.5.1/dist/leaflet.js"
-		     integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
-		     crossorigin=""></script>
+		integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
+		crossorigin=""></script>
+
+	<script src="https://unpkg.com/@geoman-io/leaflet-geoman-free@latest/dist/leaflet-geoman.min.js"></script>
+
+	<link rel="stylesheet" href="https://unpkg.com/@geoman-io/leaflet-geoman-free@latest/dist/leaflet-geoman.css" />
+
 
 	<!-- bootstrap -->
-	<link
-	    rel="stylesheet"
-	    href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-	    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-	    crossorigin="anonymous"
-	/>
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+		integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
 
 	<title>NeoMap</title>
-    </head>
+</head>
 
-    <body>
+<body>
 	<noscript>
-	    You need to enable JavaScript to run this app.
+		You need to enable JavaScript to run this app.
 	</noscript>
 	<div id="root"></div>
 	<!--
@@ -44,5 +45,6 @@
 	     To begin the development, run `npm start` or `yarn start`.
 	     To create a production bundle, use `npm run build` or `yarn build`.
 	-->
-    </body>
+</body>
+
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,13 @@ export const App = React.memo(() => {
 	 *
 	 * TODO: FIXME! Redesign neo4jService instantiation with full consideration for global window dependency
 	 */
+
+	React.useEffect(() => {
+		// on App component mount clear coordinates of shapes that could've been drawn during previous session
+		localStorage.removeItem("rectangle_coordinates");
+	}, [])
+	
+
 	neo4jService._getNeo4jDriver();
 
 	const [layers, setLayers] = React.useState([]);

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -81,7 +81,7 @@ export const Map = React.memo(({layers}) => {
 			});
 
 			map.on("pm:remove", (e) => {
-				const coords = map.pm.getGeomanLayers(true).toGeoJSON().features.flatMap(f => {
+				const coords = map.pm.getGeomanDrawLayers(true).toGeoJSON().features.flatMap(f => {
 					return f.geometry.coordinates
 				})
 				localStorage.setItem("rectangle_coordinates", JSON.stringify(coords))

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -11,7 +11,8 @@ import 'leaflet.heat';
 import 'leaflet.markercluster';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
-import 'leaflet-polylinedecorator'
+import 'leaflet-polylinedecorator';
+import "@geoman-io/leaflet-geoman-free";
 
 
 /*
@@ -41,6 +42,7 @@ export const Map = React.memo(({layers}) => {
 					}),
 				]
 			});
+
 		}
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -52,6 +54,38 @@ export const Map = React.memo(({layers}) => {
 
 		if (map) {
 			let mapBounds = new L.LatLngBounds();
+
+			// init geoman available tools 
+			map.pm.addControls({
+				drawRectangle: true,
+				removalMode: true,
+				drawMarker: false,
+				drawPolyline: false,
+				drawCircle: false,
+				drawCircleMarker: false,
+				drawPolygon: false,
+				cutPolygon: false,
+				editMode: false,
+				dragMode: false,
+				rotateMode: false,
+			});  
+			
+			// listen to `create` and `remove` events and update rectangle coordinates in local storage
+			map.on("pm:create", (e) => {
+				if (e.layer && e.layer.pm) {
+					const coords = map.pm.getGeomanDrawLayers(true).toGeoJSON().features.flatMap(f => {
+						return f.geometry.coordinates
+					})
+					localStorage.setItem("rectangle_coordinates", JSON.stringify(coords))
+				}
+			});
+
+			map.on("pm:remove", (e) => {
+				const coords = map.pm.getGeomanLayers(true).toGeoJSON().features.flatMap(f => {
+					return f.geometry.coordinates
+				})
+				localStorage.setItem("rectangle_coordinates", JSON.stringify(coords))
+			});
 
 			// On a new render pass, build new map overlays object,
 			// and replace the current map overlays object created on the last render pass

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -14,3 +14,17 @@ export function generateUkeyFromName(name) {
 	let thisName = name || generateRandomName();
     return `${thisName.replace(/\s/g,'')}${getRandomInt(0,100)}`
 }
+
+export function getMinMaxLatLongs() {
+	const rawCoords = localStorage.getItem("rectangle_coordinates") || "[]";
+	const coords = JSON.parse(rawCoords);
+	
+	const bounds = coords.map(shape => {
+		const minLat = Math.min(...shape.map(latlon => latlon[1]));
+		const minLon = Math.min(...shape.map(latlon => latlon[0]));
+		const maxLat = Math.max(...shape.map(latlon => latlon[1]));
+		const maxLon = Math.max(...shape.map(latlon => latlon[0]));
+		return {minLat, minLon, maxLat, maxLon};
+	})
+	return bounds
+}


### PR DESCRIPTION
Inspired by #51 
Not sure that this is what was meant in the issue but i needed this for my purposes so here we are

Added super basic geoman support: drawing and removing of rectangles in order to limit nodes/relationships in queries like so `minLat < node.lat < maxLat and minLon < node.lon < maxLon`. This helps when there are so many objects so app starts freezing.
But this doesn't work great, I tried it with 4 rectangles and my neo4j crashed with out of memory error and it only had ~1800 nodes and ~1800 relationships :thinking: 
Perhaps I can allow only 1 or 2 rectangles and add editing/moving support, it won't be difficult
![image](https://user-images.githubusercontent.com/33401112/135110580-a16c6c06-1774-48b5-b21c-85bf2a11ccd2.png)
![image](https://user-images.githubusercontent.com/33401112/135110629-382aff56-f6ff-4b1a-ab41-4dac64a848b9.png)
